### PR TITLE
Add temporary nav links for user testing

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -32,6 +32,14 @@ const ChildMenu = props => {
       <Menu.Item key="4" onClick={() => authService.logout()}>
         Log Out
       </Menu.Item>
+      {/* Temporary navigation for user testing */}
+      {process.env.REACT_APP_ENV === 'development' && (
+        <>
+          <Link to="/child/join">Squad</Link>
+          <br />
+          <Link to="/child/match-up">Matchup</Link>
+        </>
+      )}
     </Menu>
   );
 };


### PR DESCRIPTION
- add temporary nav links for development environment to help users navigate while Chron task controls aren't in place

Note: using React fragments and conditional rendering within the Menu container causes some strange styling. Menu doesn't like fragments for some reason. Links still work, and are for temporary user testing purposes only.