### PR TITLE
Add PointShare modal and redirect on modal close (Point Share, Mission Control)

### DIFF
--- a/src/components/pages/MissionControl/RenderMissionControl.js
+++ b/src/components/pages/MissionControl/RenderMissionControl.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
 
-import { getMissionControlText } from '../../../utils/helpers';
+import { getMissionControlText, modalPush } from '../../../utils/helpers';
 import { getChildTasks, getStory } from '../../../api';
 import { tasks } from '../../../state/actions';
 
@@ -17,6 +18,7 @@ const RenderMissionControl = props => {
   const [showModal, setShowModal] = useState(false);
   const { hasRead, hasWritten, hasDrawn } = props;
   const { authState } = useOktaAuth();
+  const { push } = useHistory();
 
   // calculate current step
   const currentStep = () => {
@@ -70,13 +72,17 @@ const RenderMissionControl = props => {
     };
   };
 
+  const closeModal = () => {
+    modalPush(push, '/child/join');
+  };
+
   return (
     <div className="mission-container">
       <InstructionsModal
         header={instructionText?.header}
         instructions={instructionText?.text}
         visible={showModal && instructionText?.header && instructionText?.text}
-        handleOk={() => setShowModal(false)}
+        handleOk={closeModal}
       />
       <div className="shaped-shadow-container">
         <div className="content-box shaped dark">

--- a/src/components/pages/PointShare/ChildRow.js
+++ b/src/components/pages/PointShare/ChildRow.js
@@ -2,14 +2,7 @@ import React from 'react';
 import Avatar from './Avatar';
 import PointShareSubmission from './PointShareSubmission';
 
-const ChildRow = ({
-  child,
-  childNum,
-  points,
-  updatePoints,
-  bgVariable,
-  openModal,
-}) => {
+const ChildRow = ({ child, childNum, points, updatePoints }) => {
   return (
     <div className="point-share-child-row content-box dark">
       <div className="avatar-container">
@@ -20,7 +13,6 @@ const ChildRow = ({
         updatePoints={updatePoints}
         imgUrl={child.ImgURL}
         points={points}
-        openModal={openModal}
         submissionType={'illustration'}
         childNum={childNum}
       />
@@ -28,7 +20,6 @@ const ChildRow = ({
         updatePoints={updatePoints}
         imgUrl={child.Pages[0].PageURL}
         points={points}
-        openModal={openModal}
         submissionType={'story'}
         childNum={childNum}
       />

--- a/src/components/pages/PointShare/PointShareSubmission.js
+++ b/src/components/pages/PointShare/PointShareSubmission.js
@@ -8,7 +8,6 @@ const submissionTypeText = submissionType => {
 };
 
 const PointShareSubmission = ({
-  openModal,
   imgUrl,
   points,
   updatePoints,

--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -1,12 +1,10 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
-import { Button } from 'antd';
-import { QuestionCircleOutlined } from '@ant-design/icons';
 import { connect } from 'react-redux';
 import { submitPoints } from '../../../api/index';
 
-import { SubmissionViewerModal, InstructionsModal } from '../../common';
+import { InstructionsModal } from '../../common';
 import { modalInstructions } from '../../../utils/helpers';
 
 import ChildRow from './ChildRow';
@@ -16,20 +14,13 @@ const PointShare = props => {
   const { push } = useHistory();
 
   const [pointsLeft, portfolioPoints, handleUpdatePoints] = usePointShare();
-  // TODO could probably abstract this into a useModal hook
-  const [modalContent, setModalContent] = useState(null);
-  const [showModal, setShowModal] = useState(false);
-  const [modalVisible, setModalVisible] = useState(true);
+  const [modalVisible, setModalVisible] = useState(false);
 
   const { authState } = useOktaAuth();
 
-  const openModal = content => {
-    setModalContent(content);
-    setShowModal(true);
-  };
-
-  const backToJoin = e => {
-    push('/child/join');
+  const closeModal = () => {
+    setModalVisible(false);
+    push('/child/dashboard');
   };
 
   const handleSubmit = e => {
@@ -52,16 +43,17 @@ const PointShare = props => {
       ];
       // TODO throws a 403 error if 'duplicate,' this error needs handling on the FE
       submitPoints(authState, formattedTeamPoints);
+      setModalVisible(true);
     }
   };
 
   return (
     <>
       <InstructionsModal
-        modalVisible={modalVisible}
-        handleCancel={() => setModalVisible(false)}
-        handleOk={() => setModalVisible(false)}
-        instructions={modalInstructions.sharePoints}
+        visible={modalVisible}
+        handleOk={closeModal}
+        header={modalInstructions.sharePointsSubmission.header}
+        instructions={modalInstructions.sharePointsSubmission.text}
       />
       <div className="point-share">
         <div className="shaped-shadow-container">
@@ -75,16 +67,12 @@ const PointShare = props => {
           childNum={'childOne'}
           points={portfolioPoints}
           updatePoints={handleUpdatePoints}
-          bgVariable={'burnt-sienna'}
-          openModal={openModal}
         />
         <ChildRow
           child={props.team.child2}
           childNum={'childTwo'}
           points={portfolioPoints}
           updatePoints={handleUpdatePoints}
-          bgVariable={'bright-sun'}
-          openModal={openModal}
         />
         <div className="center-content">
           <button onClick={handleSubmit}>Submit Points</button>

--- a/src/components/pages/PointShare/RenderPointShare.js
+++ b/src/components/pages/PointShare/RenderPointShare.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { submitPoints } from '../../../api/index';
 
 import { InstructionsModal } from '../../common';
-import { modalInstructions } from '../../../utils/helpers';
+import { modalInstructions, modalPush } from '../../../utils/helpers';
 
 import ChildRow from './ChildRow';
 import usePointShare from './usePointShare';
@@ -20,7 +20,7 @@ const PointShare = props => {
 
   const closeModal = () => {
     setModalVisible(false);
-    push('/child/dashboard');
+    modalPush(push, '/child/match-up');
   };
 
   const handleSubmit = e => {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -29,8 +29,10 @@ export const modalInstructions = {
   drawingSub:
     'Once you finish your drawing, please take a picture of all your pages and upload them.\nTips: Take one photo per page. Find good Lighting and check your photo turns out clear. Make sure each page is straight and not cropped. After all pages are uploaded, click submit.',
   submissionComplete: 'Your Story has been submitted',
-  sharePoints:
-    "Ready Squad! Read your partner's story, view their drawing and share some points.",
+  sharePointsSubmission: {
+    header: 'Submitted Points',
+    text: 'You submitted points. This text should be updated.',
+  },
   matchUp:
     "Welcome to this week's matchup. Please vote 3 times to unlock matchup scores. You may continue voting up to 10 times.",
 };

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -104,3 +104,11 @@ export const getTeamsFromFaceoffs = faceoffs => {
   });
   return teams;
 };
+
+export const modalPush = (push, url) => {
+  if (process.env.REACT_APP_ENV === 'development') {
+    push(url);
+  } else {
+    push('/child/dashboard');
+  }
+};


### PR DESCRIPTION
- clean up PointShare modal code, imports, props
- implement InstructionsModal on point share submission
- update modalInstructions text
- add modalPush helper function to redirect users
- add modalPush redirecting to point-share and mission-control

The modalPush function is used to direct users to either the dashboard (production users), or the next phase of the game (developers, testers). This is meant to make the app easier to use/navigate in development mode or user testing.