### PR TITLE
Fix modal redirecting too soon on Mission Control

### DIFF
--- a/src/components/pages/MissionControl/RenderMissionControl.js
+++ b/src/components/pages/MissionControl/RenderMissionControl.js
@@ -73,7 +73,11 @@ const RenderMissionControl = props => {
   };
 
   const closeModal = () => {
-    modalPush(push, '/child/join');
+    if (currentStep() === 'done') {
+      modalPush(push, '/child/join');
+    } else {
+      setShowModal(false);
+    }
   };
 
   return (

--- a/src/components/pages/MissionControl/RenderMissionControl.js
+++ b/src/components/pages/MissionControl/RenderMissionControl.js
@@ -72,6 +72,7 @@ const RenderMissionControl = props => {
     };
   };
 
+  // close the modal or redirect when user has completed all steps
   const closeModal = () => {
     if (currentStep() === 'done') {
       modalPush(push, '/child/join');


### PR DESCRIPTION
Will fix an issue where the modal redirects the user on any step, not allowing users to get past the first modal and submit their story/drawing. The fix will only redirect users to the dashboard (production) or /child/join route (development) after completing read, write, and draw steps.

- add check on closeModal to check currentStep to either close modal or redirect when user is done with all steps