### PR TITLE
Update login page, Okta sign-in widget styles. Add parent page styles

### DIFF
--- a/src/components/pages/LandingPage/LandingPage.js
+++ b/src/components/pages/LandingPage/LandingPage.js
@@ -1,34 +1,11 @@
 import React from 'react';
-import { Row, Col } from 'antd';
 import { LoginContainer } from '../Login';
-import LandingAnimation from '../Animations/LandingAnimation';
 
 const LandingPage = () => {
   return (
-    <>
-      <Row id="head-row">
-        <Col span={16}>
-          <LandingAnimation />
-          <p>
-            Story Squad is a game where imagination comes to play. It’s where
-            generating ideas scores big.
-          </p>
-          <p>
-            Story Squad springs storytellers into action by partnering them up
-            to participate in interactive & immersive creative challenges.
-          </p>
-          <p>
-            Become a master of your craft by submitting original drawings &
-            handwritten stories, receiving and giving real feedback, sharing
-            points in a squad-vs-squad matchup, and finally see if you won.
-          </p>
-          <p>Ready?</p>
-        </Col>
-        <Col span={8}>
-          <LoginContainer />
-        </Col>
-      </Row>
-    </>
+    <div className="parent-styles">
+      <LoginContainer />
+    </div>
   );
 };
 

--- a/src/components/pages/Login/LoginContainer.js
+++ b/src/components/pages/Login/LoginContainer.js
@@ -22,8 +22,9 @@ const LoginContainer = () => {
       // add your custom logo to your signing/register widget here.
       i18n: {
         en: {
-          'primaryauth.title': `Welcome back, sign in to continue`,
-          'primaryauth.username.placeholder': 'Email',
+          'primaryauth.title': `Sign-in to your account`,
+          'primaryauth.username.placeholder': 'Email Address',
+          needhelp: 'Don’t have an account yet? SIGN-UP HERE',
           // change title for your app
         },
       },

--- a/src/styles/components/OktaSignIn.scss
+++ b/src/styles/components/OktaSignIn.scss
@@ -44,7 +44,6 @@
   }
 }
 
-
 .auth-footer {
   text-align: center;
 }

--- a/src/styles/components/OktaSignIn.scss
+++ b/src/styles/components/OktaSignIn.scss
@@ -1,4 +1,7 @@
-// target OktaSignIn-specific class names
+/* target OktaSignIn-specific class names.
+   some of the styles from parent.scss need to be duplicated here because
+   the Okta sign-in widget overrides the .parent-styles in some cases
+*/
 .o-form-fieldset-container,
 .o-form-button-bar {
   margin: 0 auto;
@@ -7,7 +10,7 @@
 
 .o-form-fieldset-container {
   .custom-checkbox {
-    margin-top: -2rem;
+    margin-top: -4.6rem;
   }
 }
 
@@ -23,12 +26,24 @@
 }
 
 .o-form-button-bar {
-  margin-top: 6.4rem;
+  margin-top: 4.6rem;
   margin-bottom: 0.9rem;
   .button {
     margin-bottom: 0;
   }
 }
+
+.o-form-input {
+  position: relative;
+  margin-bottom: 1.6rem;
+  .o-form-input-error {
+    position: absolute;
+    top: 3.2rem;
+    color: $red-warning;
+    margin-left: 0.4rem;
+  }
+}
+
 
 .auth-footer {
   text-align: center;

--- a/src/styles/components/OktaSignIn.scss
+++ b/src/styles/components/OktaSignIn.scss
@@ -1,0 +1,35 @@
+// target OktaSignIn-specific class names
+.o-form-fieldset-container,
+.o-form-button-bar {
+  margin: 0 auto;
+  max-width: 42rem;
+}
+
+.o-form-fieldset-container {
+  .custom-checkbox {
+    margin-top: -2rem;
+  }
+}
+
+.o-form-content {
+  margin-top: 10.1rem;
+  h2, .h2 {
+    margin-top: 0;
+  }
+}
+
+.o-form-label {
+  margin-bottom: 0.7rem;
+}
+
+.o-form-button-bar {
+  margin-top: 6.4rem;
+  margin-bottom: 0.9rem;
+  .button {
+    margin-bottom: 0;
+  }
+}
+
+.auth-footer {
+  text-align: center;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -18,3 +18,4 @@
 @import './components/InfoButton.scss';
 @import './components/EmojiPicker.scss';
 @import './components/VotingForm.scss';
+@import './components/OktaSignIn.scss';

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,6 +3,7 @@
 @import 'mixins.scss';
 @import 'elements.scss';
 @import 'classes.scss';
+@import 'parent.scss';
 
 // components
 @import './components/Header.scss';

--- a/src/styles/parent.scss
+++ b/src/styles/parent.scss
@@ -22,9 +22,11 @@
   input[type='password'] {
     width: 42rem;
     height: 4.8rem;
+    padding: 0 1.4rem;
     border: 1px solid $gray-mid;
     border-radius: 0.8rem;
-    color: $gray-mid;
+    font-size: 1.6rem;
+    margin-bottom: 4.2rem;
   }
   button, .button {
     width: 42rem;

--- a/src/styles/parent.scss
+++ b/src/styles/parent.scss
@@ -1,4 +1,43 @@
 // alternative styles for login and parent dashboard.
 .parent-styles {
-
+  h2, .h2 {
+    color: $gray-blue;
+    font-size: 2.2rem;
+    letter-spacing: unset;
+    font-weight: 600;
+    margin-bottom: 4rem;
+  }
+  p, label, a {
+    font-size: 1.2rem;
+  }
+  p, label, a, input, h2, .h2, h3, .h3 {
+    font-family: $font-text-parent;
+  }
+  label {
+    font-weight: 700;
+    margin-left: 0.8rem;
+    margin-bottom: 0.7rem;
+  }
+  input[type='text'],
+  input[type='password'] {
+    width: 42rem;
+    height: 4.8rem;
+    border: 1px solid $gray-mid;
+    border-radius: 0.8rem;
+    color: $gray-mid;
+  }
+  button, .button {
+    width: 42rem;
+    height: 5.2rem;
+    font-family: $font-display-parent;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    font-weight: 700;
+    letter-spacing: 0.125rem;
+    border: none;
+    border-radius: 1.6rem;
+    color: $gray-blue-dark;
+    background: $aqua-light;
+    cursor: pointer;
+  }
 }

--- a/src/styles/parent.scss
+++ b/src/styles/parent.scss
@@ -1,0 +1,4 @@
+// alternative styles for login and parent dashboard.
+.parent-styles {
+
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -25,6 +25,7 @@ $yellow: #ffd854;
 $blue: #42caf0;
 $aqua: #6ceae6;
 $aqua-light: #8ce2e0;
+$red-warning: #EC3D52;
 // parent colors
 $gray-blue: #47525D;
 $gray-blue-dark: #323F4B;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,10 +1,13 @@
 // font imports
 @import url('https://fonts.googleapis.com/css2?family=Bangers&family=Nunito:ital,wght@0,200;0,300;0,400;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,600;1,700;1,800;1,900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Atma:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Mulish:wght@200;300;400;500;600;700;800;900&family=Open+Sans:wght@300;400;600;700;800&display=swap');
 
 // fonts
 $font-display: 'Bangers';
 $font-text: 'Atma';
+$font-text-parent: 'Open Sans';
+$font-display-parent: 'Mulish';
 
 // colors
 $black-brand: #231f20;
@@ -22,6 +25,11 @@ $yellow: #ffd854;
 $blue: #42caf0;
 $aqua: #6ceae6;
 $aqua-light: #8ce2e0;
+// parent colors
+$gray-blue: #47525D;
+$gray-blue-dark: #323F4B;
+$gray-mid: #7B8794;
+$gray-text: #4B5151;
 
 // styling
 $size-shadow: 0.4rem 0.4rem;


### PR DESCRIPTION
- remove old content from sign-in page
- add parent.scss stylesheet for parent-page-specific styling (login, parent dashboard)
- add OktaSignIn.scss to override default OktaSignIn styling
- add styles for .parent-styles elements

![image](https://user-images.githubusercontent.com/62345438/118194176-d1081e00-b3fd-11eb-852d-d50015d1a7e6.png)