### PR TITLE
feature/email password dummy inputs

### DIFF
--- a/src/components/common/ParentDashPlaceholder.js
+++ b/src/components/common/ParentDashPlaceholder.js
@@ -6,7 +6,7 @@ export default function NewProgressCharts(props) {
       className="content-box dark"
       style={{ backgroundColor: '#E5E5E5', borderRadius: '25px' }}
     >
-      <div className="ProgressBox">
+      <div className="ProgressBox parent-styles">
         <h3>This is a placeholder</h3>
         <h3>Progress Chart will be displayed here!</h3>
       </div>

--- a/src/components/pages/ParentAccountSettings/AccountSettingsForm.js
+++ b/src/components/pages/ParentAccountSettings/AccountSettingsForm.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { LockOutlined, MailOutlined } from '@ant-design/icons';
+
+function AccoountSettingsForm(props) {
+  return (
+    <div className="AccountSettingsFormContainer parent-styles">
+      <div className="inputsContainerEmailPass">
+        <div className="inputContainerEmailPass">
+          <MailOutlined className="emailPassIcon" />
+          <input
+            placeholder="&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;caroline@gmail.com"
+            disabled="true"
+          />
+          <button>Change Email</button>
+        </div>
+        <div className="inputContainerEmailPass">
+          <LockOutlined className="emailPassIcon" />
+          <input
+            placeholder="&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• • • • • • • • • • • •"
+            disabled="true"
+          />
+          <button>Change Password</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AccoountSettingsForm;

--- a/src/components/pages/ParentAccountSettings/RenderAccountSettings.js
+++ b/src/components/pages/ParentAccountSettings/RenderAccountSettings.js
@@ -4,7 +4,7 @@ import { useOktaAuth } from '@okta/okta-react';
 import bc from 'bcryptjs';
 import { getProfileData } from '../../../api';
 import PinInput from 'react-pin-input';
-// import AccountSettingsForm from '../AccountSettingsForm/AccountSettingsForm';
+import AccountSettingsForm from './AccountSettingsForm';
 
 function RenderAccountSettings() {
   const { authState } = useOktaAuth();
@@ -106,7 +106,7 @@ function RenderAccountSettings() {
         className="editFormsAndButtonsContainer"
         style={unlock ? { opacity: '.3' } : null}
       >
-        {/* <AccountSettingsForm disabled={unlock} /> */}
+        <AccountSettingsForm />
       </div>
       <div className="settings-buttons-container">
         <button

--- a/src/styles/components/AccountSettings.scss
+++ b/src/styles/components/AccountSettings.scss
@@ -9,6 +9,8 @@
   @include mobile-below {
     width: 100vw;
     background-color: transparent;
+    height: 45vh;
+    margin-bottom: 70px;
   }
 }
 .unlockButton,
@@ -38,17 +40,21 @@
   @include mobile-below {
     margin-top: 300px;
     flex-wrap: wrap;
+    h3 {
+      font-weight: 700;
+    }
     .button {
       width: 60vw;
     }
     .span {
       font-size: 1rem;
     }
+    margin-bottom: 40px;
   }
 }
 
 .editFormsAndButtonsContainer {
-  height: 30vh;
+  height: 20vh;
   display: flex;
   width: 100vw;
   flex-direction: column;
@@ -61,9 +67,19 @@
   flex-direction: column;
   justify-content: flex-start;
   width: 78vw;
+  button {
+    background: #f5f5f5;
+    border: 0.5px solid #4b5151;
+    box-sizing: border-box;
+    border-radius: 16px;
+    @include mobile-below {
+      width: 65vw;
+      font-size: 1.4rem;
+    }
+  }
   @include mobile-below {
-    width: 88vw;
-    margin-top: 30%;
+    padding: 20px;
+    width: 90vw;
     padding-bottom: 25%;
   }
 }
@@ -75,17 +91,18 @@
     flex-direction: column;
     align-items: center;
     width: 0vw;
-    height: 0vh;
+    
     margin-right: 50%;
     margin-top: 30%;
   }
+
   .pinFormModal {
     background-color: #f5f5f5;
     border-radius: 20px;
     .ant-modal-content {
       max-width: 24vw;
       max-height: 35vh;
-
+      
       h4 {
         font-size: 2rem;
         font-family: $font-text-parent;
@@ -108,8 +125,7 @@
         button {
           background-color: #fbfbfb;
           width: 12rem;
-          height: 100%;
-          margin-top: -35px;
+          max-height: 50%;
           display: flex;
           flex-direction: column;
           align-items: center;

--- a/src/styles/components/ChangePassEmail.scss
+++ b/src/styles/components/ChangePassEmail.scss
@@ -1,0 +1,55 @@
+.AccountSettingsFormContainer {
+  height: 20vh;
+  width: 80vw;
+}
+
+.inputsContainerEmailPass {
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  @include mobile-below {
+    height: 20vh;
+    
+  }
+  button {
+    width: 31vw;
+    margin-left: -25px;
+    background: #f5f5f5;
+    border: 0.5px solid #4b5151;
+    box-sizing: border-box;
+    border-radius: 16px;
+    @include mobile-below {
+      width: 40vw;
+      font-size: 1rem;
+    }
+  }
+  input {
+    width: 50vw;
+    border-radius: 20px;
+  }
+}
+.inputContainerEmailPass {
+    display: flex;
+  @include mobile-below {
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+    input {
+      width: 80vw;
+      height: 4vh;
+    }
+    button {
+      margin-left: 0px;
+    }
+    .emailPassIcon {
+      margin-top: 10px;
+    }
+  }
+  .emailPassIcon {
+    position: absolute;
+    padding: 10px;
+    min-width: 40px;
+  }
+}
+
+

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -27,3 +27,4 @@
 @import './components/ProfileSelect.scss';
 @import './components/ChildDashboard.scss';
 @import './components/AccountSettings.scss';
+@import './components/ChangePassEmail.scss';


### PR DESCRIPTION
# Description
This PR relates to moving the code for the dummy inputs over from the account settings edit section of the parent dashboard. 
Fixes #

- What work was done?
Disabled inputs were built - buttons that can be clicked to open modals allowing the user to edit and update their password were implemented. 
Why was this work done?
Following UX design Specs on Figma
What feature / user story is it for?
Move Laps pt18 Front-End code to SS repo and polish up.
- Any relevant links or images / screenshots
![Screen Shot 2021-05-31 at 10 58 29 AM](https://user-images.githubusercontent.com/62610548/120228016-29615d00-c1ff-11eb-802b-ef4536c0c9e4.png)
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
